### PR TITLE
✨ Add template parameter reference support to either<A, B>

### DIFF
--- a/tests/core/either.cxx
+++ b/tests/core/either.cxx
@@ -65,3 +65,24 @@ TEST_CASE("non-trivial-destructor") {
   }
   CHECK(hello.empty());
 }
+
+TEST_CASE("reference-on-left") {
+  int value = 4;
+  apex::either<int&, float> either { std::in_place_index<0>, value };
+  CHECK(either.has_value());
+  CHECK(either.assume_value() == value);
+}
+
+TEST_CASE("reference-on-right") {
+  int value = 4;
+  apex::either<float, int&> either { std::in_place_index<1>, value };
+  CHECK(either.has_other());
+  CHECK(either.assume_other() == value);
+}
+
+TEST_CASE("reference-for-both") {
+  int value = 4;
+  apex::either<int&, int&> either { std::in_place_index<1>, value };
+  CHECK(either.has_other());
+  CHECK(either.assume_other() == value);
+}


### PR DESCRIPTION
We only plan to support reference rebinding instead of assign-through.
Assign-through can be supported via the transformation functions. That
said, while we don't support this yet, `either<A, B>` is not yet being
used in production so we can make the change later
