### PR TITLE
♻ Refactor errors to have source_location information

### DIFF
--- a/include/apex/core/either.hpp
+++ b/include/apex/core/either.hpp
@@ -2,41 +2,9 @@
 #define APEX_CORE_EITHER_HPP
 
 #include <apex/detail/core/either.hpp>
+#include <apex/core/exception.hpp>
 
 namespace apex {
-
-template <class> struct bad_either_access;
-
-/* TODO: Support storing a backtrace of some kind... this might require our own base exception type */
-template <>
-struct bad_either_access<void> : ::std::exception {
-  explicit bad_either_access () noexcept = default;
-};
-
-template <class T>
-struct bad_either_access : bad_either_access<void> {
-  using value_type = T;
-
-  constexpr explicit bad_either_access (T const& value) noexcept(safely_copy_constructible<T>) :
-    value(value)
-  { }
-
-  constexpr explicit bad_either_access (T&& value) noexcept(safely_move_constructible<T>) :
-    value(static_cast<T&&>(value))
-  { }
-
-  constexpr virtual char const* what () const noexcept override final { return "apex::bad_either_access"; }
-
-  constexpr decltype(auto) get () const&& noexcept { return static_cast<T const&&>(this->value); }
-  constexpr decltype(auto) get () const& noexcept { return static_cast<T const&>(this->value); }
-  constexpr decltype(auto) get () && noexcept { return static_cast<T&&>(this->value); }
-  constexpr decltype(auto) get () & noexcept { return static_cast<T&>(this->value); }
-
-private:
-  value_type value;
-};
-
-template <class T> bad_either_access (T&&) -> bad_either_access<::std::remove_cvref_t<T>>;
 
 template <class A, class B>
 struct either final : private detail::either::base<A, B> {

--- a/include/apex/core/exception.hpp
+++ b/include/apex/core/exception.hpp
@@ -10,8 +10,7 @@ namespace apex {
 struct exception : ::std::exception {
   using ::std::exception::what;
 
-  exception (apex::source_location=apex::source_location::current()) noexcept;
-  exception () noexcept = delete;
+  exception (source_location=source_location::current()) noexcept;
 
   virtual ~exception () noexcept = default;
 
@@ -28,14 +27,15 @@ private:
 };
 
 struct bad_member_access : exception {
-  using exception::exception;
+  bad_member_access (source_location=source_location::current()) noexcept;
+  virtual ~bad_member_access () noexcept = default;
 };
 
 template <class> struct bad_either_access;
 
 template <>
 struct bad_either_access<void> : bad_member_access {
-  using bad_member_access::bad_member_access;
+  bad_either_access (source_location=source_location::current()) noexcept;
   virtual char const* what () const noexcept override final;
 };
 
@@ -81,7 +81,7 @@ private:
 template <class T> bad_either_access (T&&) -> bad_either_access<::std::remove_cvref_t<T>>;
 
 struct bad_optional_access final : bad_member_access {
-  using bad_member_access::bad_member_access;
+  bad_optional_access(source_location=source_location::current()) noexcept;
 
   virtual char const* what () const noexcept override final;
 };

--- a/include/apex/core/exception.hpp
+++ b/include/apex/core/exception.hpp
@@ -1,0 +1,91 @@
+#ifndef APEX_CORE_EXCEPTION_HPP
+#define APEX_CORE_EXCEPTION_HPP
+
+#include <apex/core/string.hpp>
+#include <apex/core/source.hpp>
+#include <exception>
+
+namespace apex {
+
+struct exception : ::std::exception {
+  using ::std::exception::what;
+
+  exception (apex::source_location=apex::source_location::current()) noexcept;
+  exception () noexcept = delete;
+
+  virtual ~exception () noexcept = default;
+
+  char const* function_name () const noexcept;
+  char const* file_name () const noexcept;
+  size_t column () const noexcept;
+  size_t line () const noexcept;
+
+  apex::zstring_view function () const noexcept;
+  apex::zstring_view file () const noexcept;
+
+private:
+  apex::source_location location;
+};
+
+struct bad_member_access : exception {
+  using exception::exception;
+};
+
+template <class> struct bad_either_access;
+
+template <>
+struct bad_either_access<void> : bad_member_access {
+  using bad_member_access::bad_member_access;
+  virtual char const* what () const noexcept override final;
+};
+
+template <class T>
+struct bad_either_access : bad_either_access<void> {
+  using bad_either_access<void>::bad_either_access;
+  using value_type = T;
+
+  template <class U> requires constructible_from<value_type, U>
+  constexpr explicit bad_either_access(U&& value, source_location location = source_location::current())
+  noexcept(safely_constructible_from<value_type, U>) :
+    bad_either_access<void>(location),
+    value(static_cast<U&&>(value))
+  { }
+
+  constexpr decltype(auto) get () const&& noexcept { return static_cast<value_type const&&>(this->value); }
+  constexpr decltype(auto) get () const& noexcept { return static_cast<value_type const&>(this->value); }
+  constexpr decltype(auto) get () && noexcept { return static_cast<value_type&&>(this->value); }
+  constexpr decltype(auto) get () & noexcept { return static_cast<value_type&>(this->value); }
+
+private:
+  value_type value;
+};
+
+template <class T>
+struct bad_either_access<T&> : bad_either_access<void> {
+  using bad_either_access<void>::bad_either_access;
+  using value_type = T&;
+
+  constexpr explicit bad_either_access (value_type value, source_location loc = source_location::current()) noexcept :
+    bad_either_access<void>(loc),
+    value(value)
+  { }
+
+  constexpr explicit bad_either_access (T&&) = delete;
+
+  constexpr decltype(auto) get () const noexcept { return static_cast<T const&>(this->value); }
+  constexpr decltype(auto) get () noexcept { return static_cast<T&>(this->value); }
+private:
+  value_type value;
+};
+
+template <class T> bad_either_access (T&&) -> bad_either_access<::std::remove_cvref_t<T>>;
+
+struct bad_optional_access final : bad_member_access {
+  using bad_member_access::bad_member_access;
+
+  virtual char const* what () const noexcept override final;
+};
+
+} /* namespace apex */
+
+#endif /* APEX_CORE_EXCEPTION_HPP */

--- a/include/apex/detail/core/optional.hpp
+++ b/include/apex/detail/core/optional.hpp
@@ -4,6 +4,7 @@
 #include <apex/detail/prelude/trivial.hpp>
 #include <apex/detail/prelude/enable.hpp>
 
+#include <apex/core/exception.hpp>
 #include <apex/core/concepts.hpp>
 #include <apex/core/traits.hpp>
 #include <apex/core/memory.hpp>
@@ -113,22 +114,22 @@ struct access_base : storage_base<T> {
   constexpr decltype(auto) operator * () & noexcept { return static_cast<T&>(this->storage); }
 
   constexpr decltype(auto) value () const&& noexcept(false) {
-    if (not this->has_value()) { throw std::bad_optional_access { }; }
+    if (not this->has_value()) { throw bad_optional_access { }; }
     return static_cast<value_type const&&>(**this);
   }
 
   constexpr decltype(auto) value () const& noexcept(false) {
-    if (not this->has_value()) { throw std::bad_optional_access { }; }
+    if (not this->has_value()) { throw bad_optional_access { }; }
     return static_cast<value_type const&>(**this);
   }
 
   constexpr decltype(auto) value () && noexcept(false) {
-    if (not this->has_value()) { throw std::bad_optional_access { }; }
+    if (not this->has_value()) { throw bad_optional_access { }; }
     return static_cast<value_type&&>(**this);
   }
 
   constexpr decltype(auto) value () & noexcept(false) {
-    if (not this->has_value()) { throw std::bad_optional_access { }; }
+    if (not this->has_value()) { throw bad_optional_access { }; }
     return static_cast<value_type&>(**this);
   }
 
@@ -148,12 +149,12 @@ struct access_base<T&> : storage_base<T&> {
   }
 
   constexpr T const& value () const noexcept(false) {
-    if (not this->has_value()) { throw std::bad_optional_access { }; }
+    if (not this->has_value()) { throw bad_optional_access { }; }
     return **this;
   }
 
   constexpr T& value () noexcept(false) {
-    if (not this->has_value()) { throw std::bad_optional_access { }; }
+    if (not this->has_value()) { throw bad_optional_access { }; }
     return **this;
   }
 

--- a/src/core/exception.cxx
+++ b/src/core/exception.cxx
@@ -1,0 +1,20 @@
+#include <apex/core/exception.hpp>
+
+namespace apex {
+
+exception::exception (apex::source_location location) noexcept :
+  location(location)
+{ }
+
+char const* exception::function_name () const noexcept { return this->location.function_name(); }
+char const* exception::file_name () const noexcept { return this->location.file_name(); }
+size_t exception::column () const noexcept { return this->location.column(); }
+size_t exception::line () const noexcept { return this->location.line(); }
+
+apex::zstring_view exception::function () const noexcept { return this->function_name(); }
+apex::zstring_view exception::file () const noexcept { return this->file_name(); }
+
+char const* bad_either_access<void>::what () const noexcept { return "apex::bad_either_access"; }
+char const* bad_optional_access::what () const noexcept { return "apex::bad_optional_access"; }
+
+} /* namespace apex */

--- a/src/core/exception.cxx
+++ b/src/core/exception.cxx
@@ -2,8 +2,20 @@
 
 namespace apex {
 
-exception::exception (apex::source_location location) noexcept :
+exception::exception (source_location location) noexcept :
   location(location)
+{ }
+
+bad_member_access::bad_member_access (source_location location) noexcept :
+  exception(location)
+{ }
+
+bad_either_access<void>::bad_either_access(source_location location) noexcept :
+  bad_member_access(location)
+{ }
+
+bad_optional_access::bad_optional_access(source_location location) noexcept :
+  bad_member_access(location)
 { }
 
 char const* exception::function_name () const noexcept { return this->location.function_name(); }

--- a/tests/core/optional.cxx
+++ b/tests/core/optional.cxx
@@ -104,6 +104,15 @@ TEST_CASE("star-operator") {
   STATIC_REQUIRE(apex::same_as<lvalue_type, int&>);
 }
 
+TEST_CASE("value") {
+  apex::optional<int> opt { };
+  REQUIRE_THROWS_AS(opt.value(), apex::bad_optional_access);
+  try { [[maybe_unused]] auto value = opt.value(); }
+  catch (apex::bad_optional_access const& e) {
+    REQUIRE(std::string("value") == e.function_name());
+  }
+}
+
 TEST_CASE("arrow-operator") {
   apex::optional<std::string> opt { "arrow" };
   CHECK(opt);

--- a/tests/core/source.cxx
+++ b/tests/core/source.cxx
@@ -1,6 +1,19 @@
 #include <apex/core/source.hpp>
 #include <string_view>
 
+struct structure {
+
+  structure () = default;
+
+  auto function_name () const noexcept { return this->location.function_name(); }
+  auto file_name () const noexcept { return this->location.file_name(); }
+  size_t column () const noexcept { return this->location.column(); }
+  size_t line () const noexcept { return this->location.line(); }
+
+private:
+  apex::source_location location = apex::source_location::current();
+};
+
 auto function (apex::source_location l = apex::source_location::current()) {
   return l;
 }
@@ -12,6 +25,11 @@ TEST_CASE("line-current") {
 TEST_CASE("line-previous") {
   constexpr auto location = apex::source_location::current();
   REQUIRE(location.line() == (__LINE__ - 1));
+}
+
+TEST_CASE("line-structure") {
+  structure location { };
+  REQUIRE(location.line() == 6);
 }
 
 TEST_CASE("line-function") {


### PR DESCRIPTION
We will don't have a traceback from the call site (a lot of work is
needed to improve this sort of thing), but having a way to call logging
functions with the error info will be *invaluable*.

✅ Add source_location test for aggregate initialization/constructor
info
