### PR TITLE
🐛 Fix #24 and refactor template constraints

### DIFF
--- a/include/apex/core/iterator.hpp
+++ b/include/apex/core/iterator.hpp
@@ -89,11 +89,10 @@ struct back_emplacer {
   { }
 
   template <class T>
-  back_emplacer& operator = (T&& t)
-    noexcept(noexcept(this->container->emplace_back(std::forward<T>(t))))
-    requires requires (container_type* container) { container->emplace_back(std::forward<T>(t)); }
+  requires requires (container_type* container, T&& x) { container->emplace_back(static_cast<T&&>(x)); }
+  back_emplacer& operator = (T&& x) noexcept(noexcept(this->container->emplace_back(static_cast<T&&>(x))))
   {
-    this->container.emplace_back(std::forward<T>(t));
+    this->container->emplace_back(static_cast<T&&>(x));
     return *this;
   }
 

--- a/tests/core/iterator.cxx
+++ b/tests/core/iterator.cxx
@@ -1,0 +1,14 @@
+#include <apex/core/iterator.hpp>
+#include <algorithm>
+#include <vector>
+
+TEST_CASE("back_emplacer") {
+  std::vector<int> x { 1, 2, 3, 4 };
+  std::vector<int> y;
+  std::transform(x.begin(), x.end(), apex::back_emplacer(y), [] (auto v) { return v + 1; });
+  REQUIRE(y.size() == x.size());
+  REQUIRE(x[0] == (y[0] - 1));
+  REQUIRE(x[1] == (y[1] - 1));
+  REQUIRE(x[2] == (y[2] - 1));
+  REQUIRE(x[3] == (y[3] - 1));
+}


### PR DESCRIPTION
The template constraint was written a bit incorrectly, and could result
in unreadable error messages. This fixes that, as well as speeds up
compilation by removing the call to std::forward and replacing it with
static_cast to a forwarding reference.

✅ Add back_emplacer usage test
For some reason, this never made it into the repo when it was moved to netlify
