### PR TITLE
📝 Add initial set of documentation files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: Build and Test
-on: push
+on:
+  push:
+    paths-ignore:
+      - docs/**
 jobs:
   build:
     name: Build Apex

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,41 @@
+name: Documentation
+on:
+  push:
+    paths:
+      - docs/**
+jobs:
+  build:
+    name: Build Documentation
+    runs-on: ubuntu-20.04
+    env:
+      CMAKE_GENERATOR: Ninja
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+      - name: Get Pip Cache Directory
+        run: echo "::set-output name=dir::$(pip cache dir)"
+        id: pip-cache
+      - name: Cache Dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{runner.os}}-pip-${{ hashFiles('docs/**') }}
+          restore-keys: |
+            ${{ runner.os }}-pip
+            ${{ runner.os }}
+      - name: Update Pip
+        run: python -m pip install --upgrade pip
+      - name: Install Sphinx
+        run: pip install sphinx
+      - name: Install CMake + Ninja
+        uses: pip install cmake ninja
+      - name: Configure Project
+        run: >
+          cmake -B${{github.workspace}}/build -S${{github.workspace}}
+          -DAPEX_BUILD_DOCS=ON
+      - name: Build Documentation
+        run: cmake --build build --target docs

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -1,0 +1,102 @@
+Concepts
+========
+
+There are several concepts provided by Apex that are not found within the C++
+standard library.
+
+.. namespace:: apex
+
+.. concept:: template <class T, class U> similar_to
+
+   Determines whether two types are similar (that is, in our case, if
+   ``std::remove_cvref_t<T>`` and ``std::remove_cvref_t<U>`` are the same
+   type). This is defined in such a way that ``std::same_as`` correctly
+   *subsumes* `similar_to`.
+
+.. concept:: template <class T, class U> different_from
+
+   Defined as the *inverse* of :any:`similar_to`.
+
+.. concept:: template <class F, class... Args> safely_invocable
+
+   :conjoins with: :concept:`invocable`
+
+   .. code-block:: cpp
+
+      requires (F&& f, Args&&... args) {
+        { ::std::invoke(static_cast<F&&>(f), static_cast<Args&&>(args)...) } noexcept;
+      }
+
+.. concept:: template <class T, template <class...> class U> specialization_of
+
+   If :texpr:`T` is a specialization of :texpr:`U`, this constraint will be satisfied
+
+   :usage:
+      .. code-block:: cpp
+         :name: specialization-of-usage
+
+         static_assert(specialization_of<optional<int>, optional>);
+         static_assert(specialization_of<tuple<int>, tuple>);
+
+.. concept:: template <class T> trivially_copyable
+
+   Concept version of :expr:`std::is_trivially_copyable_v<T>`
+
+Standard Concepts
+-----------------
+
+There are several concepts defined by the standard that currently have shim
+implementations until they are available within the standard implementations
+that Apex uses
+
+.. concept:: template <class F, class... Args> invocable
+
+   .. code-block:: cpp
+
+      requires (F&& f, Args&&... args) {
+        ::std::invoke(static_cast<F&&>(f), static_cast<Args&&>(args)...);
+      }
+
+.. _iterable-concepts:
+
+Iterable Concepts
+-----------------
+
+These concepts are defined in terms of :ref:`iterable-niebloids`. They are
+currently used to implement the interface for :cxx:`apex::mixin::iterator`.
+(NOTE: The mixin is currently unstable and should not be relied on until its
+API has been properly stabilized)
+
+.. namespace-push:: iter
+
+.. concept:: template <class I> indirectly_readable_from
+
+   .. todo:: This is a stub entry
+
+.. concept:: template <class I, class T> indirectly_writable_into
+
+   .. todo:: This is a stub entry
+
+.. concept:: template <class I> indirectly_addressable
+
+   .. todo:: This is a stub entry
+
+.. concept:: template <class I> weakly_incrementable
+
+   .. todo:: This is a stub entry
+
+.. concept:: template <class I> weakly_decrementable
+
+   .. todo:: This is a stub entry
+
+.. concept:: template <class I, class D> weakly_steppable
+
+   .. todo:: This is a stub entry
+
+.. concept:: template <class I, class S> distance_measurable
+
+   .. todo:: This is a stub entry
+
+.. concept:: template <class I, class S> equality_comparable
+
+.. namespace-pop::

--- a/docs/cpo.rst
+++ b/docs/cpo.rst
@@ -1,0 +1,79 @@
+Niebloids
+=========
+
+:abbr:`CPOs (Customization Point Objects)` (sometimes referred to as
+*niebloids*) are function object instances that fulfill two objectives:
+
+  1. Unconditionally trigger type requirements on its arguments
+  2. Dispatch to the correct function desired for its interface, typically with
+     an :abbr:`ADL (Argument Dependent Lookup)`
+
+The also provide the added benefit of performing a littany of checks when
+implementing a concept. In this way, a :abbr:`CPO (Customization Point Object)`
+is able to allow users to more easily "plug in" to an interface without having
+to *always* specialize a traits type, function object, or implement a free
+function.
+
+Additionally, these :abbr:`CPOs (Customization Point Objects)` are *objects* to
+postpone user provided functions that might be found during ADL.
+
+Apex provides several these to permit implementing mixins, hooking into IO
+(planned), formatting (planned), etc.
+
+.. _iterable-niebloids:
+
+Iterable Niebloids
+------------------
+
+Many of the :abbr:`CPOs (Customization Point Objects)` found here are used to
+help implement the :struct:`apex::mixin::iterator`, though they are defined in
+terms of :ref:`iterable-concepts` to more easily generate iterator categories.
+
+These CPOs are not currently limited to *just one* interface for each type of
+iterator category as this allows for greater levels of optimization as well as
+permitting some iterable types to have a partially fulfilled interface.
+
+.. namespace:: apex::iter
+
+.. note:: The customization point objects are documented as structs, however,
+          they are available as `inline constexpr` instances of the structs
+          shown.
+
+.. struct:: next
+
+   Move some iterable to is successor. Whatever iterable is passed *must* be
+   a non-:cxx:`const` lvalue reference. rvalue references will cause a compile
+   time error.
+
+   The order of operations for lookup is to first call :cxx:`.next()` on some
+   object, regardless of whather it returns :cxx:`void` or not.
+
+   .. note:: This will change at some point to require the :cxx:`.next()`
+             return *either* :cxx:`void` or some :struct:`optional`.
+
+   This is then followed by an ADL lookup form of :cxx:`next`, and lastly
+   an attempt to call :struct:`advance` with :cxx:`1`.
+
+.. struct:: prev
+
+   .. todo:: This is a stub entry at the moment.
+
+.. struct:: advance
+
+   .. todo:: This is a stub entry at the moment.
+
+.. struct:: distance_to
+
+   .. todo:: This is a stub entry at the moment.
+
+.. struct:: equal_to
+
+   .. todo:: This is a stub entry at the moment.
+
+.. struct:: read_from
+
+   .. todo:: This is a stub entry at the moment.
+
+.. struct:: write_into
+
+   .. todo:: This is a stub entry at the moment.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,19 @@
+Overview
+========
+
+Netlify's Apex library is the core of nearly everything we do regarding C++.
+It provides features such as a small shim of missing C++ standard library
+features that may not be available for our minimum compiler target, provides
+implementations of proposed C++ standard library features, a low-cost sqlite3
+wrapper with a focus on readability and ease of use over high level operations,
+journald logging (in progress), and additional types that are found in various
+states in the wild of the C++ ecosystem, but might not be able to be
+implemented in the C++ standard due to platform exclusitivity, or an inability
+to target the C++ abstract machine.
+
+.. toctree::
+   prelude
+   concepts
+   mixins
+   monads
+   cpo

--- a/docs/mixins.rst
+++ b/docs/mixins.rst
@@ -1,0 +1,94 @@
+Mixins
+======
+
+.. namespace:: apex::mixin
+
+.. concept:: template <class T> resource_handle
+
+   A resource handle is effectively any existing smart pointer *or* smart
+   pointer like type that handles construction and destruction (even if it is
+   a non-owning smart pointer like type)
+
+   :conjoins with:
+      * :concept:`totally_ordered\<T>`
+      * :concept:`swappable\<T>`
+      * :concept:`movable\<T>`
+
+   :valid expressions:
+      Given a :expr:`T` named :expr:`object`
+
+      * :expr:`object.get()` returns *either of*
+          * :expr:`typename T::pointer`
+          * :expr:`typename T::element_type*`
+      * :expr:`object.operator->()`
+      * :expr:`static_cast<bool>(object)`
+      * :expr:`object.reset(object.get())`
+      * :expr:`object.reset()`
+
+.. struct:: template <class T, resource_handle Storage> resource
+
+   This is typically used to quickly and automatically create several different
+   "handle"-like types for handling memory resources. Typically, this means
+   saving a lot of time when wrapping C APIs or C-like APIS (e.g., when using
+   `cbindgen <https://github.com/eqrion/cbindgen>`_)
+
+   :example:
+
+     .. code-block:: cpp
+
+        template <class T, class D=std::default_delete<T>>
+        using unique_resource = resource<T, ::std::unique_ptr<T, D>>;
+        struct my_resource : protected unique_resource<int> { };
+
+   .. note:: This mixin should *only* be used for wrapping object lifetimes
+             when other types do not follow RAII. This applies to both C and
+             C++ APIs
+
+   .. type:: pointer
+
+      This type alias is *either* :expr:`typename storage_type::pointer` *or*
+      :expr:`std::add_pointer_t<typename storage_type::element_type>`.
+
+   .. type:: resource_type = resource
+
+      A type alias given for child classes to easily refer to the resource
+      without having to know all of the template parameters.
+
+   .. type:: storage_type = Storage
+
+      A brief alias to refer to the :concept:`resource_handle`
+
+   .. member:: storage_type storage
+
+      This member is available to all child classes.
+
+   .. function:: resource::resource(std::nullptr_t) noexcept
+
+      This is equivalent to default constructing the resource.
+
+   .. function:: template <class... Args> resource::resource (pointer ptr, Args&&... args)
+
+      :explicit: :expr:`not sizeof...(Args)`
+      :noexcept: :expr:`safely_constructible_from<storage_type, pointer, Args...>`
+      :requires: :expr:`constructible_from<storage_type, pointer, Args...>`
+
+   .. function:: pointer get () noexcept
+
+      Equivalent to calling :expr:`storage.get()`
+
+   .. function:: pointer release () noexcept
+
+      Equivalent to :expr:`storage.release()`
+
+      :requires: :expr:`storage.release()` must be a valid expression
+
+   .. function:: template <class... Args> void reset (pointer ptr, Args&&... args) noexcept
+
+      Equivalent to calling :expr:`storage.reset(ptr, std::forward<Args>(args)...)`
+
+      :requires: :expr:`storage.reset(ptr, std::forward<Args>(args)...)` must
+                 be a valid expression
+
+   .. function:: void reset () noexcept
+
+      Equivalent to call :expr:`storage.reset()`.

--- a/docs/monads.rst
+++ b/docs/monads.rst
@@ -1,0 +1,195 @@
+Monads
+======
+
+These are a small set of types that are *monadic* in nature, even if they do
+not fit the "pure and proper" definintion of the termin monad. While other
+languages have so-called "true" monads, C++ has more limitations and
+requirements when it comes to handling monads, as we have to worry about strong
+exception guarantees, and pull-based move semantics (i.e., non-destructive
+moves).
+
+Several of the types here are already in the C++ standard. *However*, due to
+years of arguments at the academic level involving personal biases, the
+standard :expr:`std::optional` and :expr:`std::variant` do not support
+reference parameters. Furthermore, they are lacking in some features, such as
+the proposed (but not implemented) :expr:`transform`, more explicit
+:cxx:`noexcept` specifications and a faster :expr:`std::visit` in the case of
+:expr:`std::variant`. Lastly the :expr:`apex::outcome<S, M, F>` is an evolution
+of proposed types like :expr:`std::expected`, as well as third party libraries
+like Boost.LEAF_, Boost.Outcome_, and STX_, with lessons learned from each of
+their designs.
+
+Typically when interacting with these types, their member functions fall into
+several categories:
+
+  1. Unchecked
+  2. Thin
+  3. Wide
+
+More detail regarding these can be found within the :ref:`contracts` chapter
+of the documentation.
+
+.. namespace:: apex
+
+.. struct:: template <class T> optional
+
+   .. type:: value_type = T
+
+   :struct:`Optional <optional>` manages an *optional* value (hence the name),
+   much like the type found within the C++ standard library. However, unlike
+   the C++ standard library, a few additional extensions are added. These
+   include functions proposed within :wg21:`P07983`, several additional
+   functions in the same vein as :wg21:`P07983`, a :func:`try_emplace` member
+   function, several other operations found within Rust's
+   :rust:`std::option::Option`, and the ability to have an :expr:`optional<T&>`
+   (albeit with a slightly reduced interface).
+
+   Unchecked APIs require the user to verify that :expr:`has_value() == true`
+   before calling them, otherwise the program can be considered to exhibit
+   undefined behavior or is simply ill-formed (no diagnostic required).
+
+   .. function:: value_type const&& operator * () const&& noexcept
+                 value_type&& operator * () && noexcept
+
+      .. note:: These are disabled if :type:`value_type` is :expr:`T&`
+
+      :contract: Unchecked
+      :returns: rvalue reference to the stored :type:`value_type`
+
+   .. function:: value_type const& operator * () const& noexcept
+                 value_type& operator * () & noexcept
+
+      :contract: Unchecked
+      :returns: lvalue reference to the stored :type:`value_type`.
+
+   .. function:: value_type const* operator -> () const noexcept
+                 value_type* operator -> () noexcept
+
+      The arrow operator overload mimics the one found within the C++ standard
+      library's :expr:`std::optional<T>`.
+
+      :contract: Unchecked
+      :returns: Address of the stored value
+
+   .. function:: value_type const&& value () const&& noexcept(false)
+                 value_type&& value () && noexcept(false)
+
+      First checks if :expr:`has_value() == true`. If this fails,
+      :struct:`apex::bad_optional_access` is thrown.
+
+      .. note:: These are disabled if :type:`value_type` is :expr:`T&`.
+
+      :contract: Wide
+      :returns: rvalue reference to the stored :type:`value_type`.
+      :throws: :struct:`apex::bad_optional_access`
+
+   .. function:: value_type const& value () const& noexcept(false)
+                 value_type& value () & noexcept(false)
+
+      First checks if :expr:`has_value() == true`. If :cxx:`false`,
+      :struct:`apex::bad_optional_access` is thrown.
+
+      :contract: Wide
+      :returns: lvalue reference to the stored :type:`value_type`.
+      :throws: :struct:`apex::bad_optional_access`
+
+   .. function:: constexpr bool has_value () const noexcept
+
+      :contract: Thin
+      :returns: Whether the :struct:`optional` has been initialized with a
+                value or not
+
+   .. function:: constexpr specialization_of<optional> and_then (invocable<value_type const&&>&& f) const&&
+                 constexpr specialization_of<optional> and_then (invocable<value_type const&>&& f) const&
+                 constexpr specialization_of<optional> and_then (invocable<value_type&&>&& f) &&
+                 constexpr specialization_of<optional> and_then (invocable<value_type&>&& f) &
+
+      Takes any :expr:`invocable<value_type>` (where :type:`value_type` matches
+      the same qualifiers as :expr:`*this`) that returns *some kind of*
+      template specialization of :struct:`optional`. If :expr:`has_value() ==
+      true`, :expr:`f` is invoked with the value returned by :func:`operator*`,
+      otherwise an empty :struct:`optional` is returned.
+
+
+      :noexcept: :expr:`safely_invocable<decltype(f), value_type>` where
+                 :type:`value_type` has the same qualifiers as :cxx:`*this`.
+      :returns: :struct:`optional` whose :type:`value_type` is the result of
+                invoking :expr:`f`
+
+
+   .. function:: constexpr optional or_else (invocable&& f) const&&
+                 constexpr optional or_else (invocable&& f) const&
+                 constexpr optional or_else (invocable&& f) &&
+                 constexpr optional or_else (invocable&& f) &
+
+      When :expr:`has_value() == false`, the result of invoke :expr:`f` is used
+      to construct an :struct:`optional`. If the return type of :expr:`f` is
+      :expr:`void`, then an empty :expr:`optional<value_type>` is returned.
+
+      :returns: :expr:`*this` if :expr:`has_value() == true` else the result of
+                invoking :expr:`f`
+      :noexcept: :expr:`safely_invocable<decltype(f)>`
+
+   .. function:: constexpr auto transform (invocable<value_type const&&>&& f) const&&
+                 constexpr auto transform (invocable<value_type const&>&& f) const&
+                 constexpr auto transform (invocable<value_type&&>&& f) &&
+                 constexpr auto transform (invocable<value_type&>&& f) &
+
+      :noexcept: :expr:`safely_invocable<decltype(f), value_type>`
+      :returns: :struct:`optional` whose :type:`value_type` is the result of invoking
+                :expr:`f`.
+
+      :usage:
+        .. code-block:: cpp
+           :name: transform-usage
+ 
+           apex::optional<int> optional { 42 };
+           [[maybe_unused]] auto result = optional.transform([] (int i) {
+             return i + i;
+           });
+           assert(result.value() == 84);
+
+   .. function:: constexpr auto transform_or (U&& dv, invocable<value_type const&&>&& f) const&&
+                 constexpr auto transform_or (U&& dv, invocable<value_type const&>&& f) const&
+                 constexpr auto transform_or (U&& dv, invocable<value_type&&>&& f) &&
+                 constexpr auto transform_or (U&& dv, invocable<value_type&>&& f) &
+
+      .. todo:: Create a proper function signature explanation
+
+      :parameter dv: Value used as a return when :expr:`has_value() == false`.
+      :constraint: :texpr:`U&&` must be
+                   :expr:`convertible_to<invoke_result<decltype(f), value_type>>`
+      :noexcept: :expr:`safely_invocable<value_type>`
+      :return: :expr:`optional<invoke_result_t<decltype(f), value_type>>`
+               (where :type:`value_type` has the same matching qualifiers as
+               :expr:`*this`) if :expr:`has_value() == true`, or
+               :expr:static_cast<invoke_result_t<decltype(f), value_type>>(dv)`
+               when :expr:`has_value() == false`.
+
+   .. function:: constexpr auto transform_or_else (invocable&& df, invocable<value_type const&&>&& f) const&&
+                 constexpr auto transform_or_else (invocable&& df, invocable<value_type const&>&& f) const&
+                 constexpr auto transform_or_else (invocable&& df, invocable<value_type&&>&& f) &&
+                 constexpr auto transform_or_else (invocable&& df, invocable<value_type&>&& f) &
+
+       .. todo:: Create a proper function signature explanation
+
+      :parameter default_function: Function whose return type is used when
+                                   :expr:`has_value() == false`.
+      :return: :expr:`optional<invoke_result_t<decltype(f), value_type>>` if
+               :expr:`has_value() == true`, or
+               :expr:`optional<invoke_result_t<decltype(df)>>` when
+               :expr:`has_value() == false`.
+
+
+
+.. struct:: template <class A, class B> either
+
+   .. todo:: This is a stub and needs to be filled out with a proper interface
+
+.. struct:: template <class S, class M, class F> outcome
+
+   .. todo:: This is a stub and needs to be filled out with a proper interface
+
+.. _Boost.Outcome: https://boostorg.github.io/outcome/
+.. _Boost.LEAF: https://boostorg.github.io/leaf/
+.. _STX: https://lamarrr.github.io/STX

--- a/docs/prelude.rst
+++ b/docs/prelude.rst
@@ -1,0 +1,150 @@
+.. _prelude:
+
+Prelude
+=======
+
+The :ref:`prelude <prelude>` is where all important declarations are placed.
+These are the declarations and definitions that *everything* in apex relies on,
+and all definitions declared are guaranteed to be available whenever *any*
+header from apex is included.
+
+API Check Macros
+----------------
+
+It is a fairly common practice to have to slowly upgrade a codebase over time,
+lest it become stagnant and unable to compile on newer compiler releases. To
+handle this (and be "forward compatible"), some way to check for implementation
+features is needed. This is where API Check Macros are used.
+
+.. c:macro:: APEX_CHECK_ATTRIBUTE(name)
+
+   Wrapper macro around the builtin :expr:`__has_cpp_attribute` macro. This
+   ends up reading in a more clear (and consistent) style.
+
+.. c:macro:: APEX_CHECK_BUILTIN(name)
+
+   Wrapper macro for compilers that support the preprocessor function
+   :expr:`__has_builtin`. In cases where :expr:`__has_builtin` is *not*
+   supported, all calls to :c:macro:`APEX_CHECK_BUILTIN` return :expr:`false`.
+
+.. c:macro:: APEX_CHECK_FEATURE(name)
+
+   Wrapper macro around the builtin :expr:`__has_feature` macro. This ends up
+   reading in a more clear (and consistent) style.
+
+.. c:macro:: APEX_CHECK_API(name, version)
+
+   Given some identifier :expr:`name`, and some integer value :expr:`version`,
+   returns whether the :expr:`__cpp_lib_` prefixed form is greater than or equal to
+   :expr:`version`.
+
+   :usage:
+     .. code-block:: cpp
+        :name: apex-check-api-example
+
+        #if APEX_CHECK_API(ranges, 202002)
+          using ::std::ranges::begin;
+          using ::std::ranges::end;
+        #else
+          // The following lines are for exposition
+          inline constexpr struct { ... } begin;
+          inline constexpr struct { ... } end;
+        #endif
+
+.. c:macro:: APEX_CHECK_CXX(name, version)
+
+   Much like :c:macro:`APEX_CHECK_API`, :c:macro:`APEX_CHECK_CXX` checks if a
+   C++ *language feature* is available based on the name.
+
+Diagnostic Configuration Macros
+-------------------------------
+
+While we tend to rely on build systems to enable or disable our diagnostics,
+from time to time we want to always treat a diagnostic within a specific
+category or (temporarily) disable it even if we know the code is safe. For
+these reasons, we have the diagnostic configuration macros.
+
+Diagnostics passed to any of the macros take what would follow a warning flag.
+e.g., If a user wanted to *allow* ``-Wshadow``, they would write
+:expr:`APEX_DIAGNOSTIC_ALLOW(shadow)`
+
+.. c:macro:: APEX_DIAGNOSTIC_FORBID(diagnostic)
+
+   When given a :expr:`diagnostic`, the diagnostic will cause a *fatal error*.
+   when the compiler detects it has been violated. *Fatal errors* halt
+   compilation of the translation unit and no further errors will be reported.
+
+.. c:macro:: APEX_DIAGNOSTIC_DENY(diagnostic)
+
+   When given a :expr:`diagnostic`, the diagnostic will cause a *non-fatal
+   error* when the compiler detects it has been violated. *Non-fatal errors*
+   do not halt compilation of the current translation unit.
+
+.. c:macro:: APEX_DIAGNOSTIC_WARN(diagnostic)
+
+   When given a :expr:`diagnostic`, the diagnostic will cause a *warning* when
+   the compiler detects it has been violated. Warnings do not require that code
+   halt compilation, nor are they guaranteed to be correct in *all* cases.
+   Despite this, one should endeavor to fix warning diagnostics as your code
+   will actually compiler faster!
+
+.. c:macro:: APEX_DIAGNOSTIC_ALLOW(diagnostic)
+
+   When given a :expr:`diagnostic`, the compiler will either *ignore* or
+   *disable* detecting the diagnostic. This macro can be used in conjunction
+   with :c:macro:`APEX_DIAGNOSTIC_PUSH` and :c:macro:`APEX_DIAGNOSTIC_POP` to
+   temporarily disable diagnostics that have been confirmed to be false
+   positives.
+
+   .. danger:: DO NOT USE THIS JUST TO SILENCE A WARNING
+
+.. c:macro:: APEX_DIAGNOSTIC_PUSH()
+
+   Saves the current set of diagnostics onto an internal compiler diagnostics
+   stack.  A user can then modify the current set of diagnostics, then call
+   :c:macro:`APEX_DIAGNOSTIC_POP` to restore the set of diagnostics at the
+   point that :c:macro:`APEX_DIAGNOSTIC_PUSH` was first called.
+
+   This is mostly due to there not being a way to restore individual diagnostic
+   values as the preprocessor cannot store such information
+
+.. c:macro:: APEX_DIAGNOSTIC_POP()
+
+   Restores the current set of diagnostics to the state stored from a previous
+   call to :c:macro:`APEX_DIAGNOSTIC_PUSH`.
+
+   .. danger::
+
+      Do not call :c:macro:`APEX_DIAGNOSTIC_POP` if
+      :c:macro:`APEX_DIAGNOSTIC_PUSH` has not been called at least once
+
+.. c:macro:: APEX_ERROR(message)
+
+   When called, the compiler will emit an error with the message provided by
+   the user. This is useful for emitting custom error messages, however it can
+   only be used as part of the preprocessor.
+
+.. c:macro:: APEX_WARN(message)
+
+   When called, the compiler will emit a warning with the message provided by
+   the user. This is useful for emitting custom warning messages, however it
+   can only be used as part of the preprocessor.
+
+Implementation Usage Macros
+---------------------------
+
+These macros are used to detect specific information regarding an
+implementation. Currently these are only used to detect libc++ and libstdc++,
+as some features need to be disabled on each. At some point these macros will
+be deprecated (as they'll be unused) and later removed. This will occur when
+Apex moves to clang and libc++ *only* instead of clang and libstdc++.
+
+.. c:macro:: APEX_USES_LIBSTDCXX
+
+   When using libstdc++ as the underlying standard library, this macro
+   evaluates to :expr:`1`.
+
+.. c:macro:: APEX_USES_LIBCXX
+
+   When using libc++ as the underlying standard library, this macro evaluates
+   to :expr:`1`


### PR DESCRIPTION
Running `--target docs` is enough to get the target to build.

A lot of these entries are currently stubs as we need to move doxygen
comments over, write up better interfaces, clean up a few APIs, etc.

At some point I would like to get the workflow attached to this setup to
build/deploy to netlify, however the netlify build image does not have
cmake installed, and that's a requirement since our netlify/cmake
library is where the central set of documentation settings are stored at
the moment
